### PR TITLE
Filter batch runner dates to trading days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "langchain-openai>=0.3.23",
     "langgraph>=0.4.8",
     "pandas>=2.3.0",
+    "pandas-market-calendars>=4.4.2",
     "parsel>=1.10.0",
     "praw>=7.8.1",
     "python-dotenv>=1.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ typing-extensions
 langchain-openai
 langchain-experimental
 pandas
+pandas-market-calendars
 yfinance
 praw
 feedparser


### PR DESCRIPTION
## Summary
- restrict the batch runner schedule to NYSE trading days using pandas-market-calendars and guard empty ranges
- extend batch runner unit tests to cover trading-day filtering and adjust expectations
- declare the new calendar dependency in project configuration and requirements

## Testing
- PYTHONPATH=. pytest tests/cli/test_batch_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68dfbd74a3048325a4838f80a1f7c76d